### PR TITLE
Introduce new Arroyo-specific syntax (watermarks and metadata)

### DIFF
--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -1137,6 +1137,20 @@ pub enum ColumnOption {
         /// false if 'GENERATED ALWAYS' is skipped (option starts with AS)
         generated_keyword: bool,
     },
+    /// `METADATA FROM 'key'`
+    ///
+    /// A special type of column that gets its value from metadata
+    /// associated with the record.
+    ///
+    /// Example:
+    /// ```sql
+    /// CREATE TABLE logs (
+    ///   id TEXT,
+    ///   kafka_topic STRING METADATA FROM 'topic',
+    ///   log TEXT
+    /// )
+    /// ```
+    MetadataField(String),
     /// BigQuery specific: Explicit column options in a view [1] or table [2]
     /// Syntax
     /// ```sql
@@ -1200,6 +1214,7 @@ impl fmt::Display for ColumnOption {
             CharacterSet(n) => write!(f, "CHARACTER SET {n}"),
             Comment(v) => write!(f, "COMMENT '{}'", escape_single_quote_string(v)),
             OnUpdate(expr) => write!(f, "ON UPDATE {expr}"),
+            MetadataField(key) => write!(f, "METADATA FROM '{}'", escape_single_quote_string(key)),
             Generated {
                 generated_as,
                 sequence_options,

--- a/src/ast/ddl.rs
+++ b/src/ast/ddl.rs
@@ -713,6 +713,21 @@ pub enum TableConstraint {
         /// Referred column identifier list.
         columns: Vec<Ident>,
     },
+    /// Arroyo specific: Watermark definition for streaming tables
+    /// Syntax:
+    /// ```sql
+    /// WATERMARK FOR timestamp AS timestamp - INTERVAL '5 seconds'
+    /// ```
+    /// or without an expression
+    /// ```sql
+    /// WATERMARK FOR timestamp
+    /// ```
+    Watermark {
+        /// Column name to be used for the watermark
+        column_name: Ident,
+        /// Optional watermark expression
+        watermark_expr: Option<Expr>,
+    },
 }
 
 impl fmt::Display for TableConstraint {
@@ -835,6 +850,16 @@ impl fmt::Display for TableConstraint {
 
                 write!(f, " ({})", display_comma_separated(columns))?;
 
+                Ok(())
+            }
+            Self::Watermark {
+                column_name,
+                watermark_expr,
+            } => {
+                write!(f, "WATERMARK FOR {}", column_name)?;
+                if let Some(expr) = watermark_expr {
+                    write!(f, " AS {}", expr)?;
+                }
                 Ok(())
             }
         }

--- a/src/keywords.rs
+++ b/src/keywords.rs
@@ -814,6 +814,7 @@ define_keywords!(
     VIRTUAL,
     VOLATILE,
     WAREHOUSE,
+    WATERMARK,
     WEEK,
     WHEN,
     WHENEVER,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6372,6 +6372,35 @@ impl<'a> Parser<'a> {
                     columns,
                 }))
             }
+            Token::Word(w)
+                if w.keyword == Keyword::WATERMARK
+                    && dialect_of!(self is ArroyoDialect | GenericDialect) =>
+            {
+                if let Some(name) = name {
+                    return self.expected(
+                        "WATERMARK option without constraint name",
+                        TokenWithLocation {
+                            token: Token::make_keyword(&name.to_string()),
+                            location: next_token.location,
+                        },
+                    );
+                }
+
+                self.expect_keyword(Keyword::FOR)?;
+                let column_name = self.parse_identifier(false)?;
+
+                // The AS keyword and expression are optional
+                let watermark_expr = if self.parse_keyword(Keyword::AS) {
+                    Some(self.parse_expr()?)
+                } else {
+                    None
+                };
+
+                Ok(Some(TableConstraint::Watermark {
+                    column_name,
+                    watermark_expr,
+                }))
+            }
             _ => {
                 if name.is_some() {
                     self.expected("PRIMARY, UNIQUE, FOREIGN, or CHECK", next_token)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5950,6 +5950,17 @@ impl<'a> Parser<'a> {
             Ok(Some(ColumnOption::Null))
         } else if self.parse_keyword(Keyword::DEFAULT) {
             Ok(Some(ColumnOption::Default(self.parse_expr()?)))
+        } else if self.parse_keywords(&[Keyword::METADATA, Keyword::FROM])
+            && dialect_of!(self is ArroyoDialect | GenericDialect)
+        {
+            // Parse metadata field syntax: METADATA FROM 'key'
+            let next_token = self.next_token();
+            match next_token.token {
+                Token::SingleQuotedString(value, ..) => {
+                    Ok(Some(ColumnOption::MetadataField(value)))
+                }
+                _ => self.expected("string literal for metadata key", next_token),
+            }
         } else if dialect_of!(self is ClickHouseDialect| GenericDialect)
             && self.parse_keyword(Keyword::MATERIALIZED)
         {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6091,7 +6091,7 @@ impl<'a> Parser<'a> {
                         GeneratedAs::ExpStored,
                         Some(GeneratedExpressionMode::Stored),
                     ))
-                } else if dialect_of!(self is PostgreSqlDialect | ArroyoDialect) {
+                } else if dialect_of!(self is PostgreSqlDialect) {
                     // Postgres' AS IDENTITY branches are above, this one needs STORED
                     self.expected("STORED", self.peek_token())
                 } else if self.parse_keywords(&[Keyword::VIRTUAL]) {

--- a/tests/sqlparser_arroyo.rs
+++ b/tests/sqlparser_arroyo.rs
@@ -1,0 +1,80 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![warn(clippy::all)]
+
+use sqlparser::ast::{BinaryOperator, Expr, Ident, Statement, TableConstraint};
+use sqlparser::dialect::ArroyoDialect;
+use sqlparser::parser::Parser;
+use sqlparser::test_utils;
+
+#[test]
+fn test_watermark_with_expr() {
+    let sql = "CREATE TABLE orders (
+        customer_id INT,
+        order_id INT,
+        date_string TEXT,
+        timestamp TIMESTAMP GENERATED ALWAYS AS (CAST(date_string as TIMESTAMP)),
+        WATERMARK FOR timestamp AS timestamp + 5
+    ) WITH (
+        connector = 'kafka',
+        format = 'json',
+        type = 'source',
+        bootstrap_servers = 'localhost:9092',
+        topic = 'order_topic'
+    )";
+
+    let parse = Parser::parse_sql(&ArroyoDialect {}, sql).unwrap();
+    let Statement::CreateTable(ct) = parse.get(0).unwrap() else {
+        panic!("not create table")
+    };
+
+    assert_eq!(
+        ct.constraints,
+        vec![TableConstraint::Watermark {
+            column_name: Ident::new("timestamp"),
+            watermark_expr: Some(Expr::BinaryOp {
+                left: Box::new(Expr::Identifier(Ident::new("timestamp"))),
+                op: BinaryOperator::Plus,
+                right: Box::new(Expr::Value(test_utils::number("5"))),
+            }),
+        }]
+    );
+}
+
+#[test]
+fn test_watermark_without_expr() {
+    let sql = "CREATE TABLE users (
+        customer_id INT,
+        timestamp TIMESTAMP,
+        WATERMARK FOR timestamp
+    ) WITH (
+        connector = 'kafka',
+        format = 'json',
+        type = 'source',
+        bootstrap_servers = 'localhost:9092',
+        topic = 'order_topic'
+    )";
+
+    let parse = Parser::parse_sql(&ArroyoDialect {}, sql).unwrap();
+    let Statement::CreateTable(ct) = parse.get(0).unwrap() else {
+        panic!("not create table")
+    };
+
+    assert_eq!(
+        ct.constraints,
+        vec![TableConstraint::Watermark {
+            column_name: Ident::new("timestamp"),
+            watermark_expr: None,
+        }]
+    );
+}

--- a/tests/sqlparser_arroyo.rs
+++ b/tests/sqlparser_arroyo.rs
@@ -12,7 +12,7 @@
 
 #![warn(clippy::all)]
 
-use sqlparser::ast::{BinaryOperator, Expr, Ident, Statement, TableConstraint};
+use sqlparser::ast::{BinaryOperator, ColumnOption, Expr, Ident, Statement, TableConstraint};
 use sqlparser::dialect::ArroyoDialect;
 use sqlparser::parser::Parser;
 use sqlparser::test_utils;
@@ -76,5 +76,39 @@ fn test_watermark_without_expr() {
             column_name: Ident::new("timestamp"),
             watermark_expr: None,
         }]
+    );
+}
+
+#[test]
+fn test_metadata_field() {
+    let sql = "CREATE TABLE logs (
+        id TEXT,
+        kafka_topic STRING METADATA FROM 'topic',
+        log TEXT
+    )";
+
+    let parse = Parser::parse_sql(&ArroyoDialect {}, sql).unwrap();
+    let Statement::CreateTable(ct) = parse.get(0).unwrap() else {
+        panic!("not create table")
+    };
+
+    assert_eq!(ct.columns.len(), 3);
+
+    // Check the middle column with METADATA FROM
+    let column = &ct.columns[1];
+    assert_eq!(column.name, Ident::new("kafka_topic"));
+
+    // Check for the METADATA FROM option
+    let mut found_metadata = false;
+    for option_def in &column.options {
+        if let ColumnOption::MetadataField(key) = &option_def.option {
+            found_metadata = true;
+            assert_eq!(key, "topic");
+        }
+    }
+
+    assert!(
+        found_metadata,
+        "Expected METADATA FROM option in column definition"
     );
 }

--- a/tests/sqlparser_duckdb.rs
+++ b/tests/sqlparser_duckdb.rs
@@ -752,7 +752,7 @@ fn test_duckdb_union_datatype() {
             default_ddl_collation: Default::default(),
             with_aggregation_policy: Default::default(),
             with_row_access_policy: Default::default(),
-            with_tags: Default::default()
+            with_tags: Default::default(),
         }),
         stmt
     );


### PR DESCRIPTION
This PR introduces two new syntax elements for the ArroyoDialect, and also makes the meaningless STORED keyword optional for generated fields.


### WATERMARK FOR

Allows users to configure the event-time column and watermark generation expression without needing to create and then reference virtual fields:

```
WATERMARK FOR fieldname [AS watermark_expr]
```

for example,

```sql
CREATE TABLE logs (
  timestamp TIMESTAMP NOT NULL,
  id INT,
  WATERMARK FOR timestamp AS timestamp - INTERVAL '5 seconds'
)
````

### METADATA FROM

Allow users to configure a column to have metadata injected from the source:

```
field_name TYPE METADATA FROM 'key'
```

example:

```sql
CREATE TABLE logs (
    id TEXT,
    kafka_topic STRING METADATA FROM 'topic',
    log TEXT
)
```